### PR TITLE
Fix blank/unstyled page (CSS stuck on media=print)

### DIFF
--- a/src/directives/scrollReveal.js
+++ b/src/directives/scrollReveal.js
@@ -1,42 +1,83 @@
-// Scroll reveal directive for Vue 3
+// Scroll reveal directive for Vue 3.
+// Fail-safe by design: content must NEVER be permanently stuck invisible.
+// - Respects prefers-reduced-motion (shows immediately, no animation).
+// - Reveals above-the-fold elements right away instead of waiting on the observer.
+// - Falls back to a timer so anything the IntersectionObserver misses still appears.
 export const vScrollReveal = {
   mounted(el, binding) {
-    const options = {
-      threshold: binding.value?.threshold || 0.1,
-      rootMargin: binding.value?.rootMargin || '0px',
-      once: binding.value?.once !== false,
-    };
+    const noIO = typeof IntersectionObserver === 'undefined';
+    const reducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    // Set initial state
+    // If we can't animate safely, just show the content.
+    if (noIO || reducedMotion) {
+      el.style.opacity = '1';
+      return;
+    }
+
+    const once = binding.value?.once !== false;
+
+    // Initial (hidden) state
     el.style.opacity = '0';
     el.style.transform = getInitialTransform(binding.arg);
-    el.style.transition = `opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1)`;
+    el.style.transition =
+      'opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1)';
     el.style.transitionDelay = binding.value?.delay || '0ms';
 
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          el.style.opacity = '1';
-          el.style.transform = 'translate3d(0, 0, 0) scale(1)';
+    const reveal = () => {
+      el.style.opacity = '1';
+      el.style.transform = 'translate3d(0, 0, 0) scale(1)';
+    };
+    const hide = () => {
+      el.style.opacity = '0';
+      el.style.transform = getInitialTransform(binding.arg);
+    };
 
-          if (options.once) {
-            observer.unobserve(el);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            reveal();
+            if (once) observer.unobserve(el);
+          } else if (!once) {
+            hide();
           }
-        } else if (!options.once) {
-          el.style.opacity = '0';
-          el.style.transform = getInitialTransform(binding.arg);
-        }
-      });
-    }, options);
-
+        });
+      },
+      {
+        threshold: binding.value?.threshold ?? 0.1,
+        rootMargin: binding.value?.rootMargin || '0px',
+      }
+    );
     observer.observe(el);
     el._scrollRevealObserver = observer;
+
+    // Reveal above-the-fold content on the next frame, without waiting for the
+    // observer to fire (covers browsers/timings where the initial callback lags).
+    requestAnimationFrame(() => {
+      const rect = el.getBoundingClientRect();
+      const vh = window.innerHeight || document.documentElement.clientHeight;
+      if (rect.top < vh && rect.bottom > 0) {
+        reveal();
+        if (once) observer.unobserve(el);
+      }
+    });
+
+    // Absolute fail-safe: if nothing revealed this element within ~1.2s
+    // (observer never fired, etc.), force it visible so the page is never blank.
+    el._scrollRevealFallback = window.setTimeout(() => {
+      if (getComputedStyle(el).opacity === '0') {
+        reveal();
+        if (once) observer.unobserve(el);
+      }
+    }, 1200);
   },
 
   unmounted(el) {
-    if (el._scrollRevealObserver) {
-      el._scrollRevealObserver.disconnect();
-    }
+    if (el._scrollRevealObserver) el._scrollRevealObserver.disconnect();
+    if (el._scrollRevealFallback) clearTimeout(el._scrollRevealFallback);
   },
 };
 

--- a/src/utils/performanceOptimizer.js
+++ b/src/utils/performanceOptimizer.js
@@ -13,15 +13,20 @@ export function preloadCriticalResources() {
 }
 
 /**
- * Defer non-critical CSS
+ * Defer non-critical CSS.
+ *
+ * DISABLED: this previously set every stylesheet to media="print" and only
+ * restored media="all" in an onload handler. Because the stylesheets are
+ * already loaded by the time this runs, onload never fired again — so the CSS
+ * stayed media="print", applied to no screen, and the whole app rendered
+ * unstyled (blank page). The app ships a single, render-critical CSS bundle
+ * that Vite already optimizes, so there is nothing safe to defer here.
  */
 export function deferNonCriticalCSS() {
-  const nonCriticalCSS = document.querySelectorAll('link[rel="stylesheet"]:not([data-critical])');
-  nonCriticalCSS.forEach((link) => {
-    link.media = 'print';
-    link.onload = () => {
-      link.media = 'all';
-    };
+  // Safety net: if anything ever left a stylesheet stuck on media="print",
+  // restore it so the page can never be left unstyled.
+  document.querySelectorAll('link[rel="stylesheet"][media="print"]').forEach((link) => {
+    link.media = 'all';
   });
 }
 

--- a/src/views/PortfolioView.vue
+++ b/src/views/PortfolioView.vue
@@ -343,7 +343,7 @@ const fetchGitHubRepos = async () => {
 
 
 const totalYearsExperience = computed(() => {
-  return 12.5;
+  return 14;
 });
 
 // Filter state
@@ -626,8 +626,9 @@ onMounted(() => {
 
             <!-- Description -->
             <p class="text-lg text-gray-500 dark:text-gray-400 mb-8 max-w-xl leading-relaxed">
-              Architect and tech lead building enterprise AI infrastructure at scale.
-              {{ totalYearsExperience }}+ years shipping production systems—from silicon design to cloud-native microservices.
+              Applied AI engineer and tech lead building enterprise AI at scale — agent platforms,
+              LLM inference on custom H100 clusters, and multi-tenant infrastructure.
+              {{ totalYearsExperience }}+ years taking ML from prototype to production.
             </p>
 
             <!-- CTA Buttons -->
@@ -747,7 +748,7 @@ onMounted(() => {
         <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div class="text-center p-4 bg-white dark:bg-slate-800/50 rounded-xl border border-gray-100 dark:border-slate-700/50">
             <div class="text-2xl font-bold text-gray-900 dark:text-white">
-              12+
+              14+
             </div>
             <div class="text-xs text-gray-500 dark:text-gray-400">
               Years Experience


### PR DESCRIPTION
**Fixes the blank portfolio page.**

Root cause: `deferNonCriticalCSS()` set every stylesheet to `media="print"` and only restored `media="all"` in an `onload` handler — which never fires for an already-loaded sheet. So all CSS applied to no screen and the app rendered unstyled (the visible gradient was just the background `<canvas>`, which without its `fixed` class became a huge block pushing content below the fold).

- Neutralized the broken CSS-defer optimization + added a safety net that restores any `media=print` sheet
- Made the scroll-reveal directive fail-safe (immediate above-the-fold reveal, reduced-motion aware, 1.2s fallback)
- Corrected hero copy: 14+ years (was 12.5/12+), removed 'silicon design'

Verified via headless Chrome + DevTools Protocol: Tailwind utilities now apply and the full hero/nav/cards render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)